### PR TITLE
Fix item lookup in dynamic dnssec block.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,9 +101,9 @@ resource "google_dns_managed_zone" "public" {
     for_each = var.dnssec_config == {} ? [] : list(var.dnssec_config)
     iterator = config
     content {
-      kind          = lookup(config, "kind", "dns#managedZoneDnsSecConfig")
-      non_existence = lookup(config, "non_existence", "nsec3")
-      state         = lookup(config, "state", "off")
+      kind          = lookup(config.value, "kind", "dns#managedZoneDnsSecConfig")
+      non_existence = lookup(config.value, "non_existence", "nsec3")
+      state         = lookup(config.value, "state", "off")
 
       default_key_specs {
         algorithm  = lookup(var.default_key_specs_key, "algorithm", "rsasha256")


### PR DESCRIPTION
I attempted to create a public DNS zone with DNSSEC using this module, however I couldn't turn it on.

```
module "dns" {
  source = "terraform-google-modules/cloud-dns/google"
  version = "~> 3.0"
  ...
  type = "public"
  dnssec_config = {
    state = "on"
  }
}
```
Running `terraform plan` gives a plan with `dns_config.state = "off"`

Based on https://www.terraform.io/docs/configuration/expressions.html#value I have added the `value` to the lookup within the dynamic block.

Changing the source to my fork with this commit gives a plan with `dns_config.state = "on"` as expected.

I haven't run the tests in the repository because I am not set up very well to do so. Let me know if you need anything else.