### PR TITLE
Update default value and description of variable description

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,8 +51,8 @@ variable "target_network" {
 }
 
 variable "description" {
-  description = "domain description ( shown in console )"
-  default     = "domain managed by Terraform"
+  description = "zone description ( shown in console )"
+  default     = "Managed by Terraform"
   type        = string
 }
 


### PR DESCRIPTION
This PR updates the description and default value of the variable "description."

I realize it is nitpicky (especially in the face of the pandemic crisis out there), but it's been bothering me, and I might not be alone in that. 😅 

A zone is not the same thing as a domain. And since it's rather implied it's a zone, instead of "zone managed by Terraform" I'd just write "Managed by Terraform".

---

Thank you for this module, we're very happy users. 🙇 