### PR TITLE
issues/12 upgrade library version 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,14 @@ submodules, and example modules are all functionally correct.
 ### Test Environment
 The easiest way to test the module is in an isolated test project. The setup for such a project is defined in [test/setup](./test/setup/) directory.
 
-To use this setup, you need a service account with Project Creator access on a folder. Export the Service Account credentials to your environment like so:
+To use this setup, you need a service account with following roles on corresponding resource level:
+
+| Resource Level | IAM Role |
+|------|-------------|
+| Organization | Billing Account Administrator |
+| Folder | Project Creator |
+
+Export the Service Account credentials to your environment like so:
 
 ```
 export SERVICE_ACCOUNT_JSON=$(< credentials.json)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.1.0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 9.0"
 
   name              = "ci-cloud-dns"
   random_project_id = "true"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.13.0"
+  version = "~> 3.1"
 }
 
 provider "google-beta" {
-  version = "~> 2.13.0"
+  version = "~> 3.2"
 }


### PR DESCRIPTION
Issue: #12 

Summary:
This pull request is to upgrade library version in order to run integration tests.

Description:
Note that this is just to upgrade underlying lib versions so that we could start to run the tests. It does not mean the actual integration test results are all successful.

[public zone](https://github.com/terraform-google-modules/terraform-google-cloud-dns/blob/master/test/fixtures/public_zone/main.tf) test can be run successfully 

However [private zone test](https://github.com/terraform-google-modules/terraform-google-cloud-dns/blob/master/test/fixtures/private_zone/main.tf#L17-L22) will result into syntax error since we are not creating a vpc in setup step and no vpc is passed into private zone[ private_visibility_config ](https://github.com/terraform-google-modules/terraform-google-cloud-dns/blob/master/main.tf#L76-L93)

We will need another pull request to fix private zone test 

@bharathkkb Can you take a look
