### PR TITLE
Add SDK link to "labels" key/value character constraints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Functional examples are included in the [examples](./examples/) directory.
 | domain | Zone domain, must end with a period. | `string` | n/a | yes |
 | enable\_logging | Enable query logging for this ManagedZone | `bool` | `false` | no |
 | force\_destroy | Set this true to delete all records in the zone. | `bool` | `false` | no |
-| labels | A set of key/value label pairs to assign to this ManagedZone | `map(any)` | `{}` | no |
+| labels | A set of key/value label pairs to assign to this ManagedZone. Please see https://cloud.google.com/sdk/gcloud/reference/dns/managed-zones/update#--update-labels for key/value character constraints. | `map(any)` | `{}` | no |
 | name | Zone name, must be unique within the project. | `string` | n/a | yes |
 | private\_visibility\_config\_networks | List of VPC self links that can see this zone. | `list(string)` | `[]` | no |
 | project\_id | Project id for the zone. | `string` | n/a | yes |


### PR DESCRIPTION
Add link to "labels" key/value character constraints as documented by Google Cloud SDK: https://cloud.google.com/sdk/gcloud/reference/dns/managed-zones/update#--update-labels

Submitting this because I got really confused trying to add labels that had invalid characters, and even one note out there that said an "owner" key required an email value (invalid `@`, `.`). `terraform plan` was giving a pass on the invalid characters I was trying to add as labels, but `terraform apply` was failing. Additionally I had a hard time searching for the issue because the SDK doesn't reference Terraform at all so my search queries were missing it. 

Hope this isn't too annoyingly minor / malformed for a PR, I promise I read the contributing.md. I'm kinda new to all this, but a friend goaded me to "Be the change you want to see in the provider module."