### PR TITLE
chore: remove version constraint "< 5.0" for "hashicorp/google"

### DIFF
--- a/modules/dns_response_policy/version.tf
+++ b/modules/dns_response_policy/version.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.75, < 5.0"
+      version = ">= 4.75"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.75, < 5.0"
+      version = ">= 4.75"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -20,11 +20,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40, < 5.0"
+      version = ">= 4.40"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40, < 5.0"
+      version = ">= 4.40"
     }
   }
 


### PR DESCRIPTION
With 5.0 of "hashicorp/google" released, the constraint should be removed.