### PR TITLE
feat: add Primary Backup routing policy with failover support

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,40 @@ variable "recordsets" {
         location = string
         records  = list(string)
       })), [])
+      enable_geo_fencing = optional(bool, false)
+      health_check       = optional(string)
+      primary_backup = optional(object({
+        enable_geo_fencing_for_backups = optional(bool, false)
+        primary = object({
+          internal_load_balancers = optional(list(object({
+            load_balancer_type = string
+            ip_address         = string
+            port               = string
+            ip_protocol        = string
+            network_url        = string
+            project            = string
+            region             = optional(string)
+          })), [])
+          external_endpoints = optional(list(string), [])
+        })
+        backup_geo = list(object({
+          location = string
+          rrdatas  = optional(list(string), [])
+          health_checked_targets = optional(object({
+            internal_load_balancers = optional(list(object({
+              load_balancer_type = string
+              ip_address         = string
+              port               = string
+              ip_protocol        = string
+              network_url        = string
+              project            = string
+              region             = optional(string)
+            })), [])
+            external_endpoints = optional(list(string), [])
+          }))
+        }))
+        trickle_ratio = optional(number, 0.0)
+      }))
     }))
   }))
 


### PR DESCRIPTION
# Add Primary Backup Routing Policy

Adds Primary Backup routing policy for automatic DNS failover with health checks.

## Changes

- `variables.tf` - Add `primary_backup` to routing_policy
- `main.tf` - Implement primary_backup dynamic blocks  
- `README.md` - Document routing policies (WRR, GEO, Primary Backup)

## Features

- Primary/backup failover with health checks
- ILB support (L4/L7, regional/global)
- External endpoints support
- Geo-fencing and trickle ratio

## Usage

```hcl
routing_policy = {
  health_check = "https://www.googleapis.com/.../healthChecks/hc"
  primary_backup = {
    trickle_ratio = 0.1
    primary = { external_endpoints = ["10.0.0.1"] }
    backup_geo = [{
      location = "us-east1"
      health_checked_targets = { external_endpoints = ["10.1.0.1"] }
    }]
  }
}